### PR TITLE
Update civic.json file to new specification

### DIFF
--- a/civic.json
+++ b/civic.json
@@ -1,39 +1,46 @@
 {
-    "conformsTo": "http://codefordc.org/resources/specification.html",
-    "status": "Production",
-    "thumbnailUrl": "http://ajschumacher.github.io/dc_mayor_schedule/assets/img/240px-Pink-Calendar.png",
+    "name": "Mayor's Schedule Archive", 
+    "description": "archive the DC mayor's public schedule; tabularize it; give archive web interface", 
+    "license": "GPL-2.0", 
+    "status": "Production", 
+    "type": "Web App", 
+    "homepage": "http://ajschumacher.github.io/dc_mayor_schedule/", 
+    "repository": "https://github.com/ajschumacher/dc_mayor_schedule", 
+    "thumbnail": "http://ajschumacher.github.io/dc_mayor_schedule/assets/img/240px-Pink-Calendar.png", 
+    "geography": [
+        "Washington, DC"
+    ], 
     "contact": {
-        "name": "Aaron Schumacher",
-        "email": "ajschumacher@gmail.com",
-        "twitter": "@planarrowspace"
-    },
-    "bornAt": "Code for DC",
-    "geography": "Washington, DC",
-    "politicalEntity": {
-        "DC Mayor": "http://mayor.dc.gov/"
-    },
-    "communityPartner": {
-        "Code for DC": "http://codefordc.org/"
-    },
-    "type": "Web App",
-    "data": {
-        "DC mayor public schedule events": "https://github.com/ajschumacher/dc_mayor_schedule/raw/gh-pages/data/mayor_events.csv"
-    },
-    "needs": [
+        "name": "Aaron Schumacher", 
+        "email": "ajschumacher@gmail.com", 
+        "url": "https://twitter.com/@planarrowspace"
+    }, 
+    "partners": [
         {
-            "need": "updating to new data source"
+            "url": "http://codefordc.org/", 
+            "name": "Code for DC", 
+            "email": ""
+        }, 
+        {
+            "url": "http://codefordc.org", 
+            "name": "Code for DC", 
+            "email": ""
         }
-    ],
-    "categories": [
+    ], 
+    "data": [
         {
-            "category": "Open Data"
-        },
-        {
-            "category": "Politics"
-        },
-        {
-            "category": "Government"
+            "url": "https://github.com/ajschumacher/dc_mayor_schedule/raw/gh-pages/data/mayor_events.csv", 
+            "name": "DC mayor public schedule events", 
+            "metadata": ""
         }
-    ],
-    "moreInfo": "https://github.com/ajschumacher/dc_mayor_schedule"
+    ], 
+    "tags": [
+        "Open Data", 
+        "Politics", 
+        "Government"
+    ], 
+    "links": [
+        "https://github.com/ajschumacher/dc_mayor_schedule"
+    ], 
+    "id": "https://raw.githubusercontent.com/DCgov/civic.json/master/schemas/schema-v1.json"
 }


### PR DESCRIPTION
Hi, there! Code for DC is moving to an updated civic.json
specification. This pull request formats your existing
civic.json to the new standard.

Feel free to look it over and make any updates.
# 

I also see that your repository has no license.
Without a license, others have no permission to use, modify, or share your code.

This site makes it easy to add an open source license: http://choosealicense.com/
# 

The new civic.json spec keeps the required fields from the older
one, but has a number of benefits. It:
- removes fields that are hard to maintain and get out of date quickly
- combines partner fields to be more broadly applicable
- is usable by civic tech projects outside of government, as well as inside

You'll see that DC Government is using this standard in its own repos:

https://github.com/dcgov

You can learn more about the specification requirements here:

http://open.dc.gov/civic.json
